### PR TITLE
Report the values used for the P command in a visible way

### DIFF
--- a/R/send_cmd.R
+++ b/R/send_cmd.R
@@ -61,7 +61,8 @@ send_cmd <- function(con, cmd) {
     ## represent non-printable characters (as those that may occur when using
     ## the P command) both as the decimal value chosen by the user and as its
     ## corresponding raw (hexadecimal) value
-    cmd_report<- paste0(cmd_report, cmd_num, " (", as.character(num_raw), ")")
+    cmd_report <- paste0(cmd_report, cmd_num,
+                         " (0x", as.character(num_raw), ")")
   }
 
   ## construct call


### PR DESCRIPTION
As the ASCII value of the numbers given to the `P` command may correspond to non-printable characters, we report them as the decimal value given by the user input as well as the raw hexadecimal value of its ASCII code.

```
# before
sent: <P\n> | received: 'VA'  # for P10
sent: <P> | received: 'VA'    # for P1

# after
sent: <P10 (0a)> | received: 'VA'  # for P10
sent: <P1 (01)> | received: 'VA'   # for P1
```